### PR TITLE
Remove API CRUD methods typehint

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -114,9 +114,9 @@ class Api
      * @param int    $id
      * @param        $attributes
      *
-     * @return array
+     * @return mixed|array
      */
-    protected function update(string $endpoint, $id, $attributes): array
+    protected function update(string $endpoint, $id, $attributes)
     {
         $key = $endpoint.'/'.$id.'?';
 
@@ -129,9 +129,9 @@ class Api
      * @param string $endpoint
      * @param        $attributes
      *
-     * @return array
+     * @return mixed|array
      */
-    protected function create(string $endpoint, $attributes): array
+    protected function create(string $endpoint, $attributes)
     {
         return $this->getTransport()->request('/'.$endpoint, $attributes, 'post') ?? [];
     }
@@ -142,9 +142,9 @@ class Api
      * @param string $endpoint
      * @param int    $id
      *
-     * @return array
+     * @return mixed|array
      */
-    protected function delete(string $endpoint, $id): array
+    protected function delete(string $endpoint, $id)
     {
         $key = $endpoint.'/'.$id.'?';
         $this->deleteCache($key);


### PR DESCRIPTION
API may not always return an object or array but only integers or strings for example.

If CRUD methods force return type, it may throw TypeError exception.