### PR TITLE
Update ArrayAccess method return types to silence deprecation notices with PHP 8.1

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -330,7 +330,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return !is_null($this->getAttribute($offset));
     }
@@ -342,6 +342,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getAttribute($offset);
@@ -355,7 +356,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->setAttribute($offset, $value);
     }
@@ -367,7 +368,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->attributes[$offset]);
     }


### PR DESCRIPTION
This PR updates the return types of `ArrayAccess` interface methods in order to suppress [deprecation notices](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.type-compatibility-internal) when using the package with PHP 8.1.

Could use the #[\ReturnTypeWillChange] attribute throughout if that's preferable?