### PR TITLE
OAuth2 transport provider supporting of  Legue OAuth Provider defaultHeaders()

### DIFF
--- a/src/Transports/OAuth2.php
+++ b/src/Transports/OAuth2.php
@@ -73,6 +73,11 @@ class OAuth2 extends TransportCore
     public function rawRequest($endpoint, array $data = [], $method = 'get')
     {
         $this->getClient()->setHeader('Authorization', 'Bearer '.$this->getToken());
+
+        foreach($this->provider->getHeaders() as $name => $value) {
+            $this->getClient()->setHeader($name, $value);
+        }
+
         return parent::rawRequest($endpoint, $data, $method);
     }
 


### PR DESCRIPTION
Some OAuth api-es require for default headers, that not currently passed to Curl-based requests.
So adding support of this...