### PR TITLE
Update Dependencies for Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require" : {
-    "php-curl-class/php-curl-class": "^9.0",
+    "php-curl-class/php-curl-class": "^8.3 || ^9.0",
     "psr/cache": "^1.0 || ^2.0 || ^3.0"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require" : {
-    "php-curl-class/php-curl-class": "^8.3",
+    "php-curl-class/php-curl-class": "^9.0",
     "psr/cache": "^1.0 || ^2.0 || ^3.0"
   },
   "suggest": {

--- a/src/Concerns/HasAttributes.php
+++ b/src/Concerns/HasAttributes.php
@@ -2,8 +2,8 @@
 
 namespace Cristal\ApiWrapper\Concerns;
 
-use Cristal\ApiWrapper\Model;
 use LogicException;
+use Cristal\ApiWrapper\Model;
 use Cristal\ApiWrapper\Relations\RelationInterface;
 
 trait HasAttributes
@@ -42,13 +42,6 @@ trait HasAttributes
      * @var array
      */
     protected $appends = [];
-
-    /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = [];
 
     /**
      * The storage format of the model's date columns.
@@ -430,7 +423,8 @@ trait HasAttributes
         // the database connection and use that format to create the Carbon object
         // that is returned back out to the developers after we convert it here.
         return \DateTime::createFromFormat(
-            str_replace('.v', '.u', $this->getDateFormat()), $value
+            str_replace('.v', '.u', $this->getDateFormat()),
+            $value
         );
     }
 
@@ -757,7 +751,8 @@ trait HasAttributes
             // mutated attribute's actual values. After we finish mutating each of the
             // attributes we will return this final array of the mutated attributes.
             $attributes[$key] = $this->mutateAttributeForArray(
-                $key, $attributes[$key]
+                $key,
+                $attributes[$key]
             );
         }
 

--- a/src/Concerns/HasAttributes.php
+++ b/src/Concerns/HasAttributes.php
@@ -2,8 +2,8 @@
 
 namespace Cristal\ApiWrapper\Concerns;
 
-use LogicException;
 use Cristal\ApiWrapper\Model;
+use LogicException;
 use Cristal\ApiWrapper\Relations\RelationInterface;
 
 trait HasAttributes
@@ -42,6 +42,13 @@ trait HasAttributes
      * @var array
      */
     protected $appends = [];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [];
 
     /**
      * The storage format of the model's date columns.
@@ -423,8 +430,7 @@ trait HasAttributes
         // the database connection and use that format to create the Carbon object
         // that is returned back out to the developers after we convert it here.
         return \DateTime::createFromFormat(
-            str_replace('.v', '.u', $this->getDateFormat()),
-            $value
+            str_replace('.v', '.u', $this->getDateFormat()), $value
         );
     }
 
@@ -751,8 +757,7 @@ trait HasAttributes
             // mutated attribute's actual values. After we finish mutating each of the
             // attributes we will return this final array of the mutated attributes.
             $attributes[$key] = $this->mutateAttributeForArray(
-                $key,
-                $attributes[$key]
+                $key, $attributes[$key]
             );
         }
 


### PR DESCRIPTION
Bumped php-curl-class to recent version for Laravel 10.

Return type of Curl\CaseInsensitiveArray::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/php-curl-class/php-curl-class/src/Curl/CaseInsensitiveArray.php on line 197